### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import sys
 logger = logging.getLogger(__name__)
 message_handler = logging.StreamHandler(sys.stdout)
 message_handler.setFormatter(MessageFormatter())
-logger.addHandler(handler)
+logger.addHandler(message_handler)
 
 values_handler = logging.StreamHandler(sys.stderr)
 values_handler.setFormatter(ValuesFormatter())


### PR DESCRIPTION
docs: correct handler variable name in README file.

Corrected the usage of `handler` to `message_handler` in the README to reflect
the actual variable name used in the code example.